### PR TITLE
[FIX] Replacing tick-based event polling with async event streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 1.1.3",
@@ -3353,6 +3354,8 @@ dependencies = [
 name = "qobuz-player-tui"
 version = "0.6.5"
 dependencies = [
+ "crossterm",
+ "futures",
  "image",
  "qobuz-player-controls",
  "qobuz-player-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ url = "2"
 moka = { version = "0.12", features = ["future"]}
 rodio = { version = "0.21", default-features = false, features = ["flac", "playback"] }
 ratatui = "0.30"
+crossterm = { version = "0.29", features = ["event-stream"] }
 tokio_schedule = "0.3"
 rppal = "0.22"
 ratatui-image = { version = "10", default-features = false, features = ["image-defaults", "crossterm"] }

--- a/qobuz-player-tui/Cargo.toml
+++ b/qobuz-player-tui/Cargo.toml
@@ -11,6 +11,8 @@ qobuz-player-controls = { version = "*", path = "../qobuz-player-controls" }
 qobuz-player-models = { version = "*", path = "../qobuz-player-models" }
 
 ratatui.workspace = true
+crossterm.workspace = true
+futures.workspace = true
 ratatui-image.workspace = true
 tui-input.workspace = true
 image.workspace = true


### PR DESCRIPTION
# Fix laggy scrolling in TUI

## Summary

Replaced tick-based event polling with async event streaming to eliminate input lag when scrolling.

## Problem

The TUI event loop was polling for keyboard events only every 10ms via a tick interval. Combined with `tokio::select!` giving equal priority to all branches, frequent updates during playback (position, tracklist, status) could delay event processing, causing noticeable scroll lag.

## Solution

- Switched from synchronous `event::poll()` to crossterm's async `EventStream`
- Added `biased;` directive to `tokio::select!` to prioritize keyboard events
- Keyboard input is now processed immediately as a first-class async participant

## Changes

- `Cargo.toml`: Added `crossterm` with `event-stream` feature
- `qobuz-player-tui/Cargo.toml`: Added `crossterm` and `futures` dependencies
- `qobuz-player-tui/src/app.rs`:
  - Create event stream before the main loop
  - Use `biased;` in `tokio::select!` to prioritize events
  - Refactored `handle_events()` to `handle_event(Event)` to accept events from stream
  - Increased tick interval from 10ms to 100ms (now only used for notification cleanup)

## Before

```rust
_ = tick_interval.tick() => {
    if event::poll(Duration::from_millis(0))? {
        self.handle_events().await.expect("infallible");
    }
}
```

## After

```rust
Some(event_result) = event_stream.next() => {
    if let Ok(event) = event_result {
        self.handle_event(event).await.expect("infallible");
    }
}
```