### PR TITLE
Added the aur as unoffical installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Download the tar.gz file for your supported OS from the releases page, extract t
 ```
 cargo install --git https://github.com/SofusA/qobuz-player
 ```
-
+### Installation from the aur (unofficial)
+Users on arch-linux (based) systems can install it from the aur as [qobuz-player](https://aur.archlinux.org/packages/qobuz-player) ([-git](https://aur.archlinux.org/packages/qobuz-player-git))
 ### Build from source
 
 Linux dependencies: `alsa-sys-devel`, `just`.


### PR DESCRIPTION
Hi! 
[I](https://aur.archlinux.org/account/orangesoda) maintain your [software](https://aur.archlinux.org/packages/qobuz-player) on the [aur](https://wiki.archlinux.org/title/Arch_User_Repository). I added it in the README to the available installation options as options.

Greetings.