### PR TITLE
Fix Play button on playlist page pointing to wrong endpoint

### DIFF
--- a/qobuz-player-web/templates/playlist.html
+++ b/qobuz-player-web/templates/playlist.html
@@ -57,7 +57,7 @@
           <button
             class="btn btn-primary btn-play"
             hx-swap="none"
-            hx-put="/album/{{ album.id }}/play"
+            hx-put="/playlist/{{ playlist.id }}/play"
           >
             <span class="size-6">
               @defer (icons/play.html) {}


### PR DESCRIPTION
The Play button in playlist.html was using /album/{{ album.id }}/play instead of /playlist/{{ playlist.id }}/play. Since the album variable doesn't exist in the playlist template context, album.id resolved to an empty string, causing a 404 Not Found when pressing Play.

The Shuffle button was already correctly pointing to the playlist endpoint.

Fixes #270