### PR TITLE
Fix build on FreeBSD by gating keepawake behind supported platforms

### DIFF
--- a/qobuz-player-cli/Cargo.toml
+++ b/qobuz-player-cli/Cargo.toml
@@ -25,6 +25,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio_schedule.workspace = true
 time.workspace = true
-keepawake.workspace = true
 futures.workspace = true
 rodio.workspace = true
+
+[target.'cfg(any(windows, target_os = "linux", target_os = "macos"))'.dependencies]
+keepawake = { workspace = true }

--- a/qobuz-player-cli/src/cli.rs
+++ b/qobuz-player-cli/src/cli.rs
@@ -2,16 +2,21 @@ use std::{
     io::{Write, stdin, stdout},
     path::PathBuf,
     sync::Arc,
-    thread,
     time::Duration,
 };
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+use std::thread;
+
 use clap::{Parser, Subcommand};
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 use futures::executor::block_on;
 use qobuz_player_controls::{
-    AudioQuality, Status, StatusReceiver, client::Client, database::Database,
+    AudioQuality, client::Client, database::Database,
     notification::NotificationBroadcast, player::Player,
 };
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+use qobuz_player_controls::{Status, StatusReceiver};
 use qobuz_player_rfid::RfidState;
 use rodio::{DeviceTrait, cpal::traits::HostTrait};
 use snafu::prelude::*;
@@ -112,6 +117,7 @@ enum Commands {
         /// Hours before audio cache is cleaned. 0 for disable
         audio_cache_time_to_live: u32,
 
+        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
         #[clap(long, default_value_t = false)]
         /// Disable sleep inhibitor
         disable_sleep_inhibitor: bool,
@@ -223,6 +229,7 @@ pub async fn run() -> Result<(), Error> {
         audio_cache: Default::default(),
         audio_cache_time_to_live: Default::default(),
         disable_tui_album_cover: false,
+        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
         disable_sleep_inhibitor: false,
     }) {
         Commands::Open {
@@ -247,6 +254,7 @@ pub async fn run() -> Result<(), Error> {
             audio_cache,
             audio_cache_time_to_live,
             disable_tui_album_cover,
+            #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
             disable_sleep_inhibitor,
         } => {
             let database_credentials = database.get_credentials().await?;
@@ -352,6 +360,7 @@ pub async fn run() -> Result<(), Error> {
                 });
             }
 
+            #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
             if !disable_sleep_inhibitor {
                 let status_receiver = player.status();
 
@@ -527,6 +536,7 @@ fn error_exit(error: Error) {
     std::process::exit(1);
 }
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 pub fn sleep_inhibitor(mut status_receiver: StatusReceiver) {
     thread::spawn(move || {
         let mut sleep_inhibitor = SleepInhibitor::new();
@@ -547,10 +557,12 @@ pub fn sleep_inhibitor(mut status_receiver: StatusReceiver) {
     });
 }
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 struct SleepInhibitor {
     awake: Option<keepawake::KeepAwake>,
 }
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 impl SleepInhibitor {
     fn new() -> Self {
         Self { awake: None }


### PR DESCRIPTION
  keepawake 0.6.0 only supports Windows, Linux and macOS. Gate the
  dependency and all related code with cfg(any(windows, target_os = "linux",
  target_os = "macos")) so the crate compiles cleanly on FreeBSD (and any
  other unsupported platform). The sleep-inhibitor feature is silently
  disabled on those platforms with no functional regression.

Walkthrough for the developer                                                                      
                                                                                                                                        
  Root cause                                                                                                                            
                                                                                                                                        
  keepawake 0.6.0 only compiles on Windows, Linux, and macOS. Its sys/mod.rs unconditionally emits compile_error!("Unsupported cfg") on 
  any other target. FreeBSD hits that branch and the build fails.                                                                       
                                                                                                                                        
  The socket-pktinfo warning you may have seen earlier is a red herring — it compiled fine. The only real blocker is keepawake.         
                                                                                                                                        
  What was changed (two files, minimal impact)                                                                                          

  1. qobuz-player-cli/Cargo.toml

  Move keepawake out of the unconditional [dependencies] and into a platform-gated section:

  -keepawake.workspace = true
   futures.workspace = true
   rodio.workspace = true
  +
  +[target.'cfg(any(windows, target_os = "linux", target_os = "macos"))'.dependencies]
  +keepawake = { workspace = true }

  2. qobuz-player-cli/src/cli.rs

  Gate every symbol that touches keepawake with the same cfg predicate. There are six touch points:

  a) Imports — thread, block_on, Status, and StatusReceiver are used exclusively inside the sleep-inhibitor code:

  -use std::{
  -    io::{Write, stdin, stdout},
  -    path::PathBuf,
  -    sync::Arc,
  -    thread,
  -    time::Duration,
  -};
  +use std::{
  +    io::{Write, stdin, stdout},
  +    path::PathBuf,
  +    sync::Arc,
  +    time::Duration,
  +};
  +
  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
  +use std::thread;

   use clap::{Parser, Subcommand};
  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
   use futures::executor::block_on;
   use qobuz_player_controls::{
  -    AudioQuality, Status, StatusReceiver, client::Client, database::Database,
  +    AudioQuality, client::Client, database::Database,
       notification::NotificationBroadcast, player::Player,
   };
  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
  +use qobuz_player_controls::{Status, StatusReceiver};

  b) Struct field in Commands::Open:

  +        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
           #[clap(long, default_value_t = false)]
           /// Disable sleep inhibitor
           disable_sleep_inhibitor: bool,

  c) Default struct literal (unwrap_or):

  +        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
           disable_sleep_inhibitor: false,

  d) Match arm destructuring:

  +            #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
               disable_sleep_inhibitor,

  e) Call site:

  +            #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
               if !disable_sleep_inhibitor {
                   let status_receiver = player.status();
                   sleep_inhibitor(status_receiver);
               }

  f) Function and types:

  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
   pub fn sleep_inhibitor(mut status_receiver: StatusReceiver) { ... }

  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
   struct SleepInhibitor { ... }

  +#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
   impl SleepInhibitor { ... }

  Functional impact

  None. The sleep inhibitor (keeping the system awake during playback) is a pure convenience feature. On FreeBSD it is silently disabled
   — the --disable-sleep-inhibitor CLI flag simply does not appear in --help on that platform. All audio playback, the TUI, the web UI,
  RFID, and every other feature work as before.
