### PR TITLE
Add cli option for naming the qobuz connect device

### DIFF
--- a/qobuz-player-cli/src/cli.rs
+++ b/qobuz-player-cli/src/cli.rs
@@ -75,6 +75,10 @@ enum Commands {
         /// Enable qobuz connect (experimental)
         connect: bool,
 
+        #[clap(long, default_value_t = String::from("qobuz-player"))]
+        /// Set qobuz connect device name
+        connect_name: String,
+
         #[clap(short, long, default_value_t = false)]
         /// Start web server with web api and ui
         web: bool,
@@ -212,6 +216,7 @@ pub async fn run() -> Result<(), Error> {
         #[cfg(target_os = "linux")]
         disable_mpris: Default::default(),
         connect: Default::default(),
+        connect_name: Default::default(),
         web: Default::default(),
         web_secret: Default::default(),
         rfid: Default::default(),
@@ -236,6 +241,7 @@ pub async fn run() -> Result<(), Error> {
             #[cfg(target_os = "linux")]
             disable_mpris,
             connect,
+            connect_name,
             web,
             web_secret,
             rfid,
@@ -312,6 +318,7 @@ pub async fn run() -> Result<(), Error> {
                 tokio::spawn(async move {
                     if let Err(e) = qobuz_player_connect::init(
                         &app_id,
+                        connect_name,
                         controls,
                         position_receiver,
                         tracklist_receiver,

--- a/qobuz-player-connect/src/lib.rs
+++ b/qobuz-player-connect/src/lib.rs
@@ -26,6 +26,7 @@ struct ConnectState {
 
 pub async fn init(
     app_id: &str,
+    connect_name: String,
     controls: Controls,
     position_receiver: PositionReceiver,
     tracklist_receiver: TracklistReceiver,
@@ -45,7 +46,7 @@ pub async fn init(
         connected: false,
     };
 
-    connect_state.run(app_id).await?;
+    connect_state.run(app_id, connect_name).await?;
 
     Ok(())
 }
@@ -163,11 +164,11 @@ impl ConnectState {
         Ok(())
     }
 
-    async fn run(&mut self, app_id: &str) -> qonductor::Result<()> {
+    async fn run(&mut self, app_id: &str, connect_name: String) -> qonductor::Result<()> {
         let mut manager = SessionManager::start(0).await?;
 
         let mut session = manager
-            .add_device(DeviceConfig::new("qobuz-player", app_id))
+            .add_device(DeviceConfig::new(connect_name, app_id))
             .await?;
 
         tokio::spawn(async move { manager.run().await });


### PR DESCRIPTION
Does what it says on the ~tin~ pr title.